### PR TITLE
ci: add frontend CI workflow

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -1,0 +1,51 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    paths:
+      - 'frontend/**'
+
+  push:
+    branches:
+      - main
+    paths:
+      - 'frontend/**'
+
+  workflow_dispatch:
+
+jobs:
+  frontend-ci:
+    name: Run Frontend Checks
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: frontend/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Run linter
+        run: pnpm lint
+
+      - name: Generate route tree
+        run: pnpm dlx @tanstack/router-cli generate
+
+      - name: Run type check & build
+        run: pnpm build


### PR DESCRIPTION
### Summary
This PR introduces a GitHub Actions workflow to run **frontend CI** checks

---

### Workflow Overview
- **Trigger Events**:
  - `pull_request` → triggered when a PR modifies files under `frontend/**`
  - `push` → triggered on pushes to `main` that modify files under `frontend/**`
  - `workflow_dispatch` → allows manual triggering

- **Jobs**:
  1. **Checkout repository** (`actions/checkout@v4`)
  2. **Install pnpm** (`pnpm/action-setup@v4`, version 9)
  3. **Setup Node** (`actions/setup-node@v4`, Node 20, caching pnpm, lockfile path: `frontend/pnpm-lock.yaml`)
  4. **Install dependencies** via `pnpm install`
  5. **Run linter** with `pnpm lint`
  6. **Generate TanStack route tree** (`pnpm dlx @tanstack/router-cli generate`)
  7. **Run type check & build** (`pnpm build`)

---

### Benefits
- Ensures all frontend code passes linting, type checking, and builds successfully before merging to `main`.
- Provides fast feedback to developers on PRs that modify frontend files.
- Prepares the repository for automated deployment pipelines in the future.

---

### Notes
- The workflow runs in the `frontend` subdirectory (`working-directory: frontend`) to match the project structure.
- Generated files (`routeTree.gen.ts`) are recreated in CI to avoid committing them to the repository.