### PR TITLE
ci:  - move linting and `pnpm install --frozen-lockfile` 

### DIFF
--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -39,13 +39,13 @@ jobs:
           cache-dependency-path: frontend/pnpm-lock.yaml
 
       - name: Install dependencies
-        run: pnpm install
-
-      - name: Run linter
-        run: pnpm lint
+        run: pnpm install --frozen-lockfile
 
       - name: Generate route tree
         run: pnpm dlx @tanstack/router-cli generate
+
+      - name: Run linter
+        run: pnpm lint
 
       - name: Run type check & build
         run: pnpm build


### PR DESCRIPTION
- Move linting to run after the route tree is generated to prevent errors from missing imports

- Use `pnpm install --frozen-lockfile` to enforce exact dependency versions from `pnpm-lock.yaml` and ensure reproducible CI builds